### PR TITLE
chore: drop 'dev-requirements.txt'

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,0 @@
-sqlalchemy>=1.1.9
-google-cloud-bigquery>=1.6.0
-future==0.18.2
-
-pytest==6.2.5
-pytest-flake8==1.0.7
-pytz==2021.3


### PR DESCRIPTION
It is not used by any CI or other script.

Motivated by:
https://github.com/googleapis/python-db-dtypes-pandas/pull/21#issuecomment-933659497