### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "db-dtypes",
     "name_pretty": "Pandas Data Types for SQL systems (BigQuery, Spanner)",
-    "client_documentation": "https://googleapis.dev/python/db-dtypes/latest/index.html",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/db-dtypes/latest",
     "release_level": "beta",
     "language": "python",
     "library_type": "INTEGRATION",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.