### PR TITLE
fix: dbdate and dbtime support set item will null values

### DIFF
--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -106,6 +106,9 @@ class TimeArray(core.BaseDatetimeArray):
             r"(?:\.(?P<fraction>\d*))?)?)?\s*$"
         ).match,
     ) -> Optional[numpy.datetime64]:
+        if isinstance(scalar, numpy.datetime64):
+            return scalar
+
         # Convert pyarrow values to datetime.time.
         if isinstance(scalar, (pyarrow.Time32Scalar, pyarrow.Time64Scalar)):
             scalar = (
@@ -116,7 +119,7 @@ class TimeArray(core.BaseDatetimeArray):
             )
 
         if pandas.isna(scalar):
-            return None
+            return numpy.datetime64("NaT")
         if isinstance(scalar, datetime.time):
             return pandas.Timestamp(
                 year=1970,
@@ -238,12 +241,15 @@ class DateArray(core.BaseDatetimeArray):
         scalar,
         match_fn=re.compile(r"\s*(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+)\s*$").match,
     ) -> Optional[numpy.datetime64]:
+        if isinstance(scalar, numpy.datetime64):
+            return scalar
+
         # Convert pyarrow values to datetime.date.
         if isinstance(scalar, (pyarrow.Date32Scalar, pyarrow.Date64Scalar)):
             scalar = scalar.as_py()
 
         if pandas.isna(scalar):
-            return None
+            return numpy.datetime64("NaT")
         elif isinstance(scalar, datetime.date):
             return pandas.Timestamp(
                 year=scalar.year, month=scalar.month, day=scalar.day

--- a/db_dtypes/core.py
+++ b/db_dtypes/core.py
@@ -100,14 +100,6 @@ class BaseDatetimeArray(
             return NotImplemented
         return op(self._ndarray, other._ndarray)
 
-    def __setitem__(self, key, value):
-        if is_list_like(value):
-            _datetime = self._datetime
-            value = [_datetime(v) for v in value]
-        elif not pandas.isna(value):
-            value = self._datetime(value)
-        return super().__setitem__(key, value)
-
     def _from_factorized(self, unique, original):
         return self.__class__(unique)
 
@@ -119,6 +111,16 @@ class BaseDatetimeArray(
         Validate and convert a scalar value to datetime64[ns] for storage in
         backing NumPy array.
         """
+        return self._datetime(value)
+
+    def _validate_setitem_value(self, value):
+        """
+        Convert a value for use in setting a value in the backing numpy array.
+        """
+        if is_list_like(value):
+            _datetime = self._datetime
+            return [_datetime(v) for v in value]
+
         return self._datetime(value)
 
     def any(

--- a/db_dtypes/pandas_backports.py
+++ b/db_dtypes/pandas_backports.py
@@ -126,7 +126,7 @@ class NDArrayBackedExtensionArray(pandas.core.arrays.base.ExtensionArray):
         return self.__class__(value, self._dtype)
 
     def __setitem__(self, index, value):
-        self._ndarray[index] = value
+        self._ndarray[index] = self._validate_setitem_value(value)
 
     def __len__(self):
         return len(self._ndarray)

--- a/tests/unit/test_time.py
+++ b/tests/unit/test_time.py
@@ -73,8 +73,14 @@ def test_box_func():
         # Fractional seconds can cause rounding problems if cast to float. See:
         # https://github.com/googleapis/python-db-dtypes-pandas/issues/18
         ("0:0:59.876543", datetime.time(0, 0, 59, 876543)),
+        (
+            numpy.datetime64("1970-01-01 00:00:59.876543"),
+            datetime.time(0, 0, 59, 876543),
+        ),
         ("01:01:01.010101", datetime.time(1, 1, 1, 10101)),
+        (pandas.Timestamp("1970-01-01 01:01:01.010101"), datetime.time(1, 1, 1, 10101)),
         ("09:09:09.090909", datetime.time(9, 9, 9, 90909)),
+        (datetime.time(9, 9, 9, 90909), datetime.time(9, 9, 9, 90909)),
         ("11:11:11.111111", datetime.time(11, 11, 11, 111111)),
         ("19:16:23.987654", datetime.time(19, 16, 23, 987654)),
         # Microsecond precision


### PR DESCRIPTION
feat: dbdate and dbtime support numpy.datetime64 values

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-db-dtypes-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Towards #28  🦕
