### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,2 +1,11 @@
-# Make sure we test with pandas 1.1.0. The Python version isn't that relevant.
-pandas==1.1.0
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+packaging==17.0
+# Make sure we test with pandas 0.24.2. The Python version isn't that relevant.
+pandas==0.24.2
+pyarrow==3.0.0
+numpy==1.16.6


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6