### PR TITLE
fix: remove python version upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     ],
     platforms="Posix; MacOS X; Windows",
     install_requires=dependencies,
-    python_requires=">=3.7, <3.11",
+    python_requires=">=3.7",
     tests_require=["pytest"],
 )


### PR DESCRIPTION
Capping to <3.11 prevents projects from using (or testing) this package on 3.11 (which I'd like to do for internal projects), so unless there is a known breaking issue in 3.11, this removes the pin. There may be some conflicting opinions, but [this post](https://iscinumpy.dev/post/bound-version-constraints/#tldr) lays out a couple challenges with _libraries_ pinning upper bound. Notably, neither [pandas](https://github.com/pandas-dev/pandas/blob/edf0fce742bf9443e38c035deffa10f6a18591bd/setup.cfg#L38) nor [pyarrow](https://github.com/apache/arrow/blob/93b63e8f3b4880927ccbd5522c967df79e926cda/python/setup.py#L754) set a python upper bound.

--

I'm just making the PR real quick since it is a small change, but happy to close if there are concerns (or open an issue if it needs further discussion).

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-db-dtypes-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕