### PR TITLE
fix: avoid out-of-range nanoseconds field in pandas 1.5.x

### DIFF
--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -150,7 +150,8 @@ class TimeArray(core.BaseDatetimeArray):
                 hour=int(hour),
                 minute=int(minute) if minute else 0,
                 second=int(second) if second else 0,
-                nanosecond=nanosecond,
+                microsecond=nanosecond // 1000,
+                nanosecond=nanosecond % 1000,
             ).to_datetime64()
         else:
             raise TypeError("Invalid value type", scalar)


### PR DESCRIPTION
Using out-of-range nanoseconds in pandas is deprecated (https://github.com/pandas-dev/pandas/issues/48538) and broken in pandas 1.5 (https://github.com/pandas-dev/pandas/issues/48255).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-db-dtypes-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #133 
Fixes #132 
Fixes #121 
Fixes #120 
Fixes #119 
Fixes #118 
Fixes #117
🦕
