### PR TITLE
ci: Mark the prerelease presubmit check as optional

### DIFF
--- a/.github/workflows/unittest-prerelease.yml
+++ b/.github/workflows/unittest-prerelease.yml
@@ -4,7 +4,7 @@ on:
       - main
 name: unittest-prerelease
 jobs:
-  unit:
+  unit-prerelease:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
`unittest-prerelease / unit (3.10)` appears as a required check on presubmits. I believe that is because `unit (3.10)` is a required check under Github Settings.  I think we need to rename `unit` to `unit-prerelease` in `.github/workflows/unittest-prerelease.yml` so that it is not part of the `unit (3.10)` required check.