### PR TITLE
bug: add import and object reference due to upstream changes

### DIFF
--- a/tests/compliance/date/test_date_compliance.py
+++ b/tests/compliance/date/test_date_compliance.py
@@ -22,6 +22,7 @@ https://github.com/pandas-dev/pandas/blob/main/pandas/tests/extension/test_perio
 
 import pandas
 from pandas.tests.extension import base
+import pandas._testing as tm
 import pytest
 
 import db_dtypes
@@ -88,7 +89,7 @@ class TestMethods(base.BaseMethodsTests):
         result = pandas.Series(all_data).value_counts(dropna=dropna).sort_index()
         expected = pandas.Series(other).value_counts(dropna=dropna).sort_index()
 
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_diff(self):
         pytest.xfail(

--- a/tests/compliance/time/test_time_compliance.py
+++ b/tests/compliance/time/test_time_compliance.py
@@ -22,6 +22,7 @@ https://github.com/pandas-dev/pandas/blob/main/pandas/tests/extension/test_perio
 
 import pandas
 from pandas.tests.extension import base
+import pandas._testing as tm
 import pytest
 
 import db_dtypes
@@ -88,7 +89,7 @@ class TestMethods(base.BaseMethodsTests):
         result = pandas.Series(all_data).value_counts(dropna=dropna).sort_index()
         expected = pandas.Series(other).value_counts(dropna=dropna).sort_index()
 
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
 
 class TestParsing(base.BaseParsingTests):


### PR DESCRIPTION
Due to an upstream change in how a module was imported and referenced, we needed to update some of our compliance tests to match.

Fixes #200 🦕
Fixes #201 🦕
Fixes #202 🦕
Fixes #203 🦕
Fixes #204 🦕
Fixes #205 🦕
Fixes #206 🦕
Fixes #207 🦕
