### PR TITLE
bug: fixes flake8==6.1.0 bug, unpins flake8==6.0.0

### DIFF
--- a/db_dtypes/core.py
+++ b/db_dtypes/core.py
@@ -90,10 +90,12 @@ class BaseDatetimeArray(
     def _cmp_method(self, other, op):
         """Compare array values, for use in OpsMixin."""
 
-        if is_scalar(other) and (pandas.isna(other) or type(other) is self.dtype.type):
+        if is_scalar(other) and (
+            pandas.isna(other) or isinstance(other, self.dtype.type)
+        ):
             other = type(self)([other])
 
-        if type(other) is type(self):
+        if type(other) is not type(self):
             return NotImplemented
 
         oshape = getattr(other, "shape", None)

--- a/db_dtypes/core.py
+++ b/db_dtypes/core.py
@@ -90,10 +90,10 @@ class BaseDatetimeArray(
     def _cmp_method(self, other, op):
         """Compare array values, for use in OpsMixin."""
 
-        if is_scalar(other) and (pandas.isna(other) or type(other) == self.dtype.type):
+        if is_scalar(other) and (pandas.isna(other) or type(other) is self.dtype.type):
             other = type(self)([other])
 
-        if type(other) != type(self):
+        if type(other) is type(self):
             return NotImplemented
 
         oshape = getattr(other, "shape", None)

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,10 +26,6 @@ import warnings
 
 import nox
 
-# Pin flake8 to 6.0.0
-# See https://github.com/googleapis/python-db-dtypes-pandas/issues/199
-FLAKE8_VERSION = "flake8==6.0.0"
-
 BLACK_VERSION = "black==22.3.0"
 ISORT_VERSION = "isort==5.10.1"
 LINT_PATHS = ["docs", "db_dtypes", "tests", "noxfile.py", "setup.py"]
@@ -88,7 +84,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install(FLAKE8_VERSION, BLACK_VERSION)
+    session.install("flake8", BLACK_VERSION)
     session.run(
         "black",
         "--check",

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,10 @@ import warnings
 
 import nox
 
+# Pin flake8 to 6.0.0
+# See https://github.com/googleapis/python-db-dtypes-pandas/issues/199
+FLAKE8_VERSION = "flake8==6.0.0"
+
 BLACK_VERSION = "black==22.3.0"
 ISORT_VERSION = "isort==5.10.1"
 LINT_PATHS = ["docs", "db_dtypes", "tests", "noxfile.py", "setup.py"]
@@ -84,7 +88,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", BLACK_VERSION)
+    session.install(FLAKE8_VERSION, BLACK_VERSION)
     session.run(
         "black",
         "--check",
@@ -283,6 +287,7 @@ def unit_prerelease(session):
 
 
 def install_systemtest_dependencies(session, *constraints):
+
     # Use pre-release gRPC for system tests.
     # Exclude version 1.52.0rc1 which has a known issue.
     # See https://github.com/grpc/grpc/issues/32163

--- a/noxfile.py
+++ b/noxfile.py
@@ -283,7 +283,6 @@ def unit_prerelease(session):
 
 
 def install_systemtest_dependencies(session, *constraints):
-
     # Use pre-release gRPC for system tests.
     # Exclude version 1.52.0rc1 which has a known issue.
     # See https://github.com/grpc/grpc/issues/32163


### PR DESCRIPTION
* Updates some type assertion to conform to [E721](https://www.flake8rules.com/rules/E721.html)
* Unpins `flake8==6.0.0`
* Similar to https://github.com/googleapis/python-bigquery/pull/1659

Fixes #199 🦕
