### PR TITLE
bug: remove flake8 pin in owlbot

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,10 +26,7 @@ import warnings
 
 import nox
 
-# Pin flake8 to 6.0.0
-# See https://github.com/googleapis/python-db-dtypes-pandas/issues/199
-FLAKE8_VERSION = "flake8==6.0.0"
-
+FLAKE8_VERSION = "flake8==6.1.0"
 BLACK_VERSION = "black==22.3.0"
 ISORT_VERSION = "isort==5.10.1"
 LINT_PATHS = ["docs", "db_dtypes", "tests", "noxfile.py", "setup.py"]

--- a/owlbot.py
+++ b/owlbot.py
@@ -56,14 +56,6 @@ s.replace(
     ["noxfile.py"], "--cov=google", "--cov=db_dtypes",
 )
 
-s.replace(["noxfile.py"],
-    """FLAKE8_VERSION = \"flake8==6.1.0\"""",
-    """# Pin flake8 to 6.0.0
-# See https://github.com/googleapis/python-db-dtypes-pandas/issues/199
-FLAKE8_VERSION = "flake8==6.0.0"
-"""
-)
-
 # There are no system tests for this package.
 old_sessions = """
     "unit",


### PR DESCRIPTION
Amends #211, the noxfile change was reverted by owlbot, so this PR changes the `owlbot.py` file.