### PR TITLE
test: adds basic action yaml file to enable stalebot action

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,32 @@
+name: 'Label Stale Issues'
+description: 'Label issues with no recent activity'
+author: 'GitHub'
+inputs:
+  repo-token:
+    description: 'Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.'
+    required: false
+    default: ${{ github.token }}
+  stale-issue-message:
+    description: 'TEST: labeling issues as stale if they exceed a specific age.'
+    required: true
+  days-before-issue-stale:
+    description: 'The number of days old an issue can be before marking it stale. Set to -1 to never mark issues as stale automatically. Override "days-before-stale" option regarding only the issues.'
+    required: false
+    default: '850'
+  stale-issue-label:
+    description: 'The label to apply when an issue is stale.'
+    required: false
+    default: 'TEST LABEL Stale'
+  exempt-issue-labels:
+    description: 'The labels that mean an issue is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2").'
+    default: 'Do not stale'
+    required: false
+  close-issue-reason:
+    description: 'The reason to use when closing an issue.'
+    default: 'not_planned'
+    required: false
+outputs:
+  closed-issues-prs:
+    description: 'List of all closed issues and pull requests.'
+  staled-issues-prs:
+    description: 'List of all staled issues and pull requests.'


### PR DESCRIPTION
This is a test PR to look at the possible use of the stalebot Github Action for controlling Issue aging.


