### PR TITLE
bug: refine constraint to avoid numpy pandas incompatability

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -170,6 +170,9 @@ def default(session, tests_path):
     )
     install_unittest_dependencies(session, "-c", constraints_path)
 
+    # list installed packages
+    session.run("python", "-m", "pip", "list")
+
     # Run py.test against the unit tests.
     session.run(
         "py.test",

--- a/noxfile.py
+++ b/noxfile.py
@@ -170,9 +170,6 @@ def default(session, tests_path):
     )
     install_unittest_dependencies(session, "-c", constraints_path)
 
-    # list installed packages
-    session.run("python", "-m", "pip", "list")
-
     # Run py.test against the unit tests.
     session.run(
         "py.test",

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,2 +1,3 @@
 # Make sure we test with pandas 1.3.0. The Python version isn't that relevant.
 pandas==1.3.0
+numpy<2.0.0


### PR DESCRIPTION
Pins the version of `numpy` used with `python 3.9` to be less than `2.0.0`. 

There is a potentially unexpected interaction between `pandas` and `numpy` here. Depending on the version we use for each, we get different results in terms of pass/fail for the unit tests associated with `python 3.9`

|numpy version|pandas version|unit-3.9 pass/fail|
|-|-|-|
|2.0.0|1.3.0|fail|
|2.0.0|2.2.2|pass|
|2.0.0|1.5.3|fail|
|1.26.4|1.5.3|pass|
|1.26.4|1.3.0|pass|

This [appears to be a known incompatibility](https://github.com/numpy/numpy/issues/26710) between how `pip` resolves the dependency versions for `numpy` and `pandas` and the only current fix is to pin versions to something that "works" to avoid allowing `pip` to resolve into a failing state. (NOTE the linked issue references various versions of numpy and pandas, depending on the combination, inlcuding 3.9 throughout the thread, even though the title references `python 3.12`)

Fixes #275 🦕
