### PR TITLE
chore: add sync-repo-settings.yaml to exclude unit-test for Python 3.7

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,34 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings
+# Rules for main branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `main`
+- pattern: main
+  requiresCodeOwnerReviews: true
+  requiresStrictStatusChecks: false
+  requiredStatusCheckContexts:
+    - 'conventionalcommits.org'
+    - 'cla/google'
+    - 'docs'
+    - 'lint'
+    - 'unit (3.8)'
+    - 'unit (3.9)'
+    - 'unit (3.10)'
+    - 'unit (3.11)'
+    - 'unit (3.12)'
+    - 'cover'
+permissionRules:
+  - team: actools-python
+    permission: admin
+  - team: actools
+    permission: admin
+  - team: api-bigquery
+    permission: push
+  - team: api-bigquery-dataframe
+    permission: push
+  - team: yoshi-python
+    permission: push
+  - team: python-samples-owners
+    permission: push
+  - team: python-samples-reviewers
+    permission: push


### PR DESCRIPTION
This change adds the `sync-repo-settings.yaml` setting to exclude unit-test for Python 3.7, which is going to be dropped by #286. 

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-db-dtypes-pandas/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
