### PR TITLE
chore: Adds python eol deprecation warning

### DIFF
--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -18,6 +18,7 @@ Pandas Data Types for SQL systems (BigQuery, Spanner)
 import datetime
 import re
 from typing import Optional, Union
+import warnings
 
 import numpy
 import packaging.version

--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -347,7 +347,7 @@ class DateArray(core.BaseDatetimeArray):
         return super().__sub__(other)
 
 
-sys_major, sys_minor, _ = _versions_helpers.extract_runtime_version()
+sys_major, sys_minor, sys_micro = _versions_helpers.extract_runtime_version()
 if sys_major == 3 and sys_minor in (7, 8):
     warnings.warn(
         "The python-bigquery library will stop supporting Python 3.7 "

--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -29,6 +29,8 @@ import pyarrow.compute
 
 from db_dtypes import core
 from db_dtypes.version import __version__
+from . import _versions_helpers
+
 
 date_dtype_name = "dbdate"
 time_dtype_name = "dbtime"
@@ -342,6 +344,18 @@ class DateArray(core.BaseDatetimeArray):
             return self._ndarray - other._ndarray
 
         return super().__sub__(other)
+
+
+sys_major, sys_minor, _ = _versions_helpers.extract_runtime_version()
+if sys_major == 3 and sys_minor in (7, 8):
+    warnings.warn(
+        "The python-bigquery library will stop supporting Python 3.7 "
+        "and Python 3.8 in a future major release expected in Q4 2024. "
+        f"Your Python version is {sys_major}.{sys_minor}.{sys_micro}. We "
+        "recommend that you update soon to ensure ongoing support. For "
+        "more details, see: [Google Cloud Client Libraries Supported Python Versions policy](https://cloud.google.com/python/docs/supported-python-versions)",
+        PendingDeprecationWarning,
+    )
 
 
 if not JSONArray or not JSONDtype:

--- a/db_dtypes/_versions_helpers.py
+++ b/db_dtypes/_versions_helpers.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helper functions for verifying versions of installed modules."""
+
+
+import sys
+from typing import Tuple
+
+
+def extract_runtime_version() -> Tuple[int, int, int]:
+    # Retrieve the version information
+    version_info = sys.version_info
+
+    # Extract the major, minor, and micro components
+    major = version_info.major
+    minor = version_info.minor
+    micro = version_info.micro
+
+    # Display the version number in a clear format
+    return major, minor, micro

--- a/noxfile.py
+++ b/noxfile.py
@@ -173,6 +173,7 @@ def default(session, tests_path):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         f"--junitxml={os.path.split(tests_path)[-1]}_{session.python}_sponge_log.xml",
         "--cov=db_dtypes",
         "--cov=tests/unit",
@@ -250,6 +251,7 @@ def prerelease(session, tests_path):
     session.run(
         "py.test",
         "--quiet",
+        "-W default::PendingDeprecationWarning",
         f"--junitxml={os.path.split(tests_path)[-1]}_prerelease_{session.python}_sponge_log.xml",
         "--cov=db_dtypes",
         "--cov=tests/unit",
@@ -345,6 +347,7 @@ def system(session):
         session.run(
             "py.test",
             "--quiet",
+            "-W default::PendingDeprecationWarning",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
             *session.posargs,
@@ -353,6 +356,7 @@ def system(session):
         session.run(
             "py.test",
             "--quiet",
+            "-W default::PendingDeprecationWarning",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,
             *session.posargs,
@@ -529,6 +533,7 @@ def prerelease_deps(session):
         session.run(
             "py.test",
             "--verbose",
+            "-W default::PendingDeprecationWarning",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
             *session.posargs,
@@ -537,6 +542,7 @@ def prerelease_deps(session):
         session.run(
             "py.test",
             "--verbose",
+            "-W default::PendingDeprecationWarning",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,
             *session.posargs,


### PR DESCRIPTION
Adds a `PendingDeprecationWarning` and additional code logic to output that warning if the user attempts to install the repo using Python 3.7 or 3.8.

The expected outcome is that the system will display a `PendingDeprecationWarning` if it detects Python runtimes 3.7 or 3.8, and will display nothing if using more recent Python runtimes 3.9 to 3.x.