### PR TITLE
fix: support correct numpy construction for dbjson dtype in pandas 1.5

### DIFF
--- a/db_dtypes/json.py
+++ b/db_dtypes/json.py
@@ -231,3 +231,16 @@ class JSONArray(arrays.ArrowExtensionArray):
         if name in ["min", "max"]:
             raise TypeError("JSONArray does not support min/max reducntion.")
         super()._reduce(name, skipna=skipna, keepdims=keepdims, **kwargs)
+
+    def __array__(self, dtype=None, copy: bool | None = None) -> np.ndarray:
+        """Correctly construct numpy arrays when passed to `np.asarray()`."""
+        pa_type = self.pa_data.type
+        data = self
+        if dtype is None:
+            empty = pa.array([], type=pa_type).to_numpy(zero_copy_only=False)
+            dtype = empty.dtype
+        result = np.empty(len(data), dtype=dtype)
+        mask = data.isna()
+        result[mask] = pd.NA
+        result[~mask] = data[~mask].pa_data.to_numpy()
+        return result

--- a/db_dtypes/json.py
+++ b/db_dtypes/json.py
@@ -241,6 +241,6 @@ class JSONArray(arrays.ArrowExtensionArray):
             dtype = empty.dtype
         result = np.empty(len(data), dtype=dtype)
         mask = data.isna()
-        result[mask] = pd.NA
+        result[mask] = self._dtype.na_value
         result[~mask] = data[~mask].pa_data.to_numpy()
         return result

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,3 +1,3 @@
-# Make sure we test with pandas 1.5.0. The Python version isn't that relevant.
+# Make sure we test with pandas 1.5.3. The Python version isn't that relevant.
 pandas==1.5.3
 numpy==1.24.0

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 
 import numpy as np
 import pandas as pd
@@ -85,6 +86,12 @@ def test_deterministic_json_serialization():
 
 
 def test_to_numpy():
+    """
+    Verifies that JSONArray can be cast to a NumPy array.
+    This test ensures compatibility with Python 3.9 and replicates the behavior
+    of the `test_to_numpy` test from `test_json_compliance.py::TestJSONArrayCasting`,
+    which is run with Python 3.12 environments only.
+    """
     data = db_dtypes.JSONArray._from_sequence(JSON_DATA.values())
     expected = np.asarray(data)
 
@@ -92,4 +99,18 @@ def test_to_numpy():
     pd._testing.assert_equal(result, expected)
 
     result = pd.Series(data).to_numpy()
+    pd._testing.assert_equal(result, expected)
+
+
+def test_as_numpy_array():
+    data = db_dtypes.JSONArray._from_sequence(JSON_DATA.values())
+    result = np.asarray(data)
+    expected = np.asarray(
+        [
+            json.dumps(value, sort_keys=True, separators=(",", ":"))
+            if value is not None
+            else pd.NA
+            for value in JSON_DATA.values()
+        ]
+    )
     pd._testing.assert_equal(result, expected)

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -15,7 +15,6 @@
 
 import numpy as np
 import pandas as pd
-import pandas._testing as tm
 import pytest
 
 import db_dtypes
@@ -90,7 +89,7 @@ def test_to_numpy():
     expected = np.asarray(data)
 
     result = data.to_numpy()
-    tm.assert_equal(result, expected)
+    pd._testing.assert_equal(result, expected)
 
     result = pd.Series(data).to_numpy()
-    tm.assert_equal(result, expected)
+    pd._testing.assert_equal(result, expected)

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 
+import numpy as np
 import pandas as pd
+import pandas._testing as tm
 import pytest
 
 import db_dtypes
@@ -81,3 +83,14 @@ def test_deterministic_json_serialization():
     y = {"b": 1, "a": 0}
     data = db_dtypes.JSONArray._from_sequence([y])
     assert data[0] == x
+
+
+def test_to_numpy():
+    data = db_dtypes.JSONArray._from_sequence(JSON_DATA.values())
+    expected = np.asarray(data)
+
+    result = data.to_numpy()
+    tm.assert_equal(result, expected)
+
+    result = pd.Series(data).to_numpy()
+    tm.assert_equal(result, expected)


### PR DESCRIPTION
This change fixes an issue where pandas 1.5 would fail to display `dbjson` data correctly. Previously, attempting to format a DataFrame with `dbjson` values through `np.asarray(db)` calls, could result in a `ValueError` during the formatting process.


