### PR TITLE
fix: Compact JSON serialization for the dbjson dtype

### DIFF
--- a/db_dtypes/json.py
+++ b/db_dtypes/json.py
@@ -143,7 +143,9 @@ class JSONArray(arrays.ArrowExtensionArray):
         else:
             # `sort_keys=True` sorts dictionary keys before serialization, making
             # JSON comparisons deterministic.
-            return json.dumps(value, sort_keys=True)
+            # `separators=(',', ':')` eliminate whitespace to get the most compact
+            # JSON representation.
+            return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
     @staticmethod
     def _deserialize_json(value):

--- a/tests/compliance/json/test_json_compliance.py
+++ b/tests/compliance/json/test_json_compliance.py
@@ -31,7 +31,8 @@ class TestJSONArrayCasting(base.BaseCastingTests):
         # Use `json.dumps(str)` instead of passing `str(obj)` directly to the super method.
         result = pd.Series(data[:5]).astype(str)
         expected = pd.Series(
-            [json.dumps(x, sort_keys=True) for x in data[:5]], dtype=str
+            [json.dumps(x, sort_keys=True, separators=(",", ":")) for x in data[:5]],
+            dtype=str,
         )
         tm.assert_series_equal(result, expected)
 
@@ -46,7 +47,7 @@ class TestJSONArrayCasting(base.BaseCastingTests):
         # Use `json.dumps(str)` instead of passing `str(obj)` directly to the super method.
         result = pd.Series(data[:5]).astype(nullable_string_dtype)
         expected = pd.Series(
-            [json.dumps(x, sort_keys=True) for x in data[:5]],
+            [json.dumps(x, sort_keys=True, separators=(",", ":")) for x in data[:5]],
             dtype=nullable_string_dtype,
         )
         tm.assert_series_equal(result, expected)
@@ -119,11 +120,14 @@ class TestJSONArrayInterface(base.BaseInterfaceTests):
     def test_array_interface(self, data):
         result = np.array(data)
         # Use `json.dumps(data[0])` instead of passing `data[0]` directly to the super method.
-        assert result[0] == json.dumps(data[0])
+        assert result[0] == json.dumps(data[0], sort_keys=True, separators=(",", ":"))
 
         result = np.array(data, dtype=object)
         # Use `json.dumps(x)` instead of passing `x` directly to the super method.
-        expected = np.array([json.dumps(x) for x in data], dtype=object)
+        expected = np.array(
+            [json.dumps(x, sort_keys=True, separators=(",", ":")) for x in data],
+            dtype=object,
+        )
         # if expected.ndim > 1:
         #     # nested data, explicitly construct as 1D
         #     expected = construct_1d_object_array_from_listlike(list(data))


### PR DESCRIPTION
This change optimizes the `dbjson` serialization by removing whitespace when calling `json.dumps`. The compact format ensures compatibility with `bpd.read_gbq` whose pyarrow string values contains the compact format too.

Fixes internal issue 354782342 🦕
