### PR TITLE
feat: Add Arrow types for efficient JSON data representation in pyarrow

### DIFF
--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -50,7 +50,7 @@ _NP_BOX_DTYPE = "datetime64[us]"
 # To use JSONArray and JSONDtype, you'll need Pandas 1.5.0 or later. With the removal
 # of Python 3.7 compatibility, the minimum Pandas version will be updated to 1.5.0.
 if packaging.version.Version(pandas.__version__) >= packaging.version.Version("1.5.0"):
-    from db_dtypes.json import ArrowJSONType, JSONArray, JSONDtype
+    from db_dtypes.json import JSONArray, JSONArrowScalar, JSONArrowType, JSONDtype
 else:
     JSONArray = None
     JSONDtype = None
@@ -359,7 +359,7 @@ if sys_major == 3 and sys_minor in (7, 8):
     )
 
 
-if not JSONArray or not JSONDtype or not ArrowJSONType:
+if not JSONArray or not JSONDtype:
     __all__ = [
         "__version__",
         "DateArray",
@@ -370,11 +370,12 @@ if not JSONArray or not JSONDtype or not ArrowJSONType:
 else:
     __all__ = [
         "__version__",
-        "ArrowJSONType",
         "DateArray",
         "DateDtype",
         "JSONDtype",
         "JSONArray",
+        "JSONArrowType",
+        "JSONArrowScalar",
         "TimeArray",
         "TimeDtype",
     ]

--- a/db_dtypes/__init__.py
+++ b/db_dtypes/__init__.py
@@ -30,8 +30,8 @@ import pyarrow.compute
 
 from db_dtypes import core
 from db_dtypes.version import __version__
-from . import _versions_helpers
 
+from . import _versions_helpers
 
 date_dtype_name = "dbdate"
 time_dtype_name = "dbtime"
@@ -50,7 +50,7 @@ _NP_BOX_DTYPE = "datetime64[us]"
 # To use JSONArray and JSONDtype, you'll need Pandas 1.5.0 or later. With the removal
 # of Python 3.7 compatibility, the minimum Pandas version will be updated to 1.5.0.
 if packaging.version.Version(pandas.__version__) >= packaging.version.Version("1.5.0"):
-    from db_dtypes.json import JSONArray, JSONDtype
+    from db_dtypes.json import ArrowJSONType, JSONArray, JSONDtype
 else:
     JSONArray = None
     JSONDtype = None
@@ -359,7 +359,7 @@ if sys_major == 3 and sys_minor in (7, 8):
     )
 
 
-if not JSONArray or not JSONDtype:
+if not JSONArray or not JSONDtype or not ArrowJSONType:
     __all__ = [
         "__version__",
         "DateArray",
@@ -370,6 +370,7 @@ if not JSONArray or not JSONDtype:
 else:
     __all__ = [
         "__version__",
+        "ArrowJSONType",
         "DateArray",
         "DateDtype",
         "JSONDtype",

--- a/db_dtypes/json.py
+++ b/db_dtypes/json.py
@@ -269,15 +269,6 @@ class ArrowJSONType(pa.ExtensionType):
         # No parameters are necessary
         return b""
 
-    def __eq__(self, other):
-        if isinstance(other, pyarrow.BaseExtensionType):
-            return type(self) == type(other)
-        else:
-            return NotImplemented
-
-    def __ne__(self, other) -> bool:
-        return not self == other
-
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type, serialized) -> ArrowJSONType:
         # return an instance of this subclass

--- a/db_dtypes/json.py
+++ b/db_dtypes/json.py
@@ -96,9 +96,9 @@ class JSONArray(arrays.ArrowExtensionArray):
         else:
             raise NotImplementedError(f"Unsupported pandas version: {pd.__version__}")
 
-    def __arrow_array__(self):
+    def __arrow_array__(self, type=None):
         """Convert to an arrow array. This is required for pyarrow extension."""
-        return self.pa_data
+        return pa.array(self.pa_data, type=JSONArrowType())
 
     @classmethod
     def _box_pa(
@@ -159,12 +159,7 @@ class JSONArray(arrays.ArrowExtensionArray):
     def _deserialize_json(value):
         """A static method that converts a JSON string back into its original value."""
         if not pd.isna(value):
-            # Attempt to interpret the value as a JSON object.
-            # If it's not valid JSON, treat it as a regular string.
-            try:
-                return json.loads(value)
-            except json.JSONDecodeError:
-                return value
+            return json.loads(value)
         else:
             return value
 
@@ -278,9 +273,6 @@ class JSONArrowType(pa.ExtensionType):
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type, serialized) -> JSONArrowType:
         return JSONArrowType()
-
-    def __hash__(self) -> int:
-        return hash(str(self))
 
     def to_pandas_dtype(self):
         return JSONDtype()

--- a/tests/compliance/json/test_json_compliance.py
+++ b/tests/compliance/json/test_json_compliance.py
@@ -22,10 +22,6 @@ import pandas.tests.extension.base as base
 import pytest
 
 
-class TestJSONArrayAccumulate(base.BaseAccumulateTests):
-    pass
-
-
 class TestJSONArrayCasting(base.BaseCastingTests):
     def test_astype_str(self, data):
         # Use `json.dumps(str)` instead of passing `str(obj)` directly to the super method.

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -118,6 +118,11 @@ def test_as_numpy_array():
     pd._testing.assert_equal(result, expected)
 
 
+def test_json_arrow_array():
+    data = db_dtypes.JSONArray._from_sequence(JSON_DATA.values())
+    assert isinstance(data.__arrow_array__(), pa.ExtensionArray)
+
+
 def test_json_arrow_storage_type():
     arrow_json_type = db_dtypes.JSONArrowType()
     assert arrow_json_type.extension_name == "dbjson"


### PR DESCRIPTION
This change is adding `ArrowJSONtype` to extend pyarrow type for the JSONDtype extension type. 

- [X] Fixes internal bug b/312728178 (design doc: go/bf-json)
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes internal bug b/312728178 🦕
