### PR TITLE
fix: Updates noxfile with pip freeze and pandas 1.2

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -88,6 +88,7 @@ def lint(session):
     serious code quality issues.
     """
     session.install(FLAKE8_VERSION, BLACK_VERSION)
+    session.run("python", "-m", "pip", "freeze")
     session.run(
         "black",
         "--check",
@@ -100,6 +101,7 @@ def lint(session):
 def blacken(session):
     """Run black. Format code to uniform standard."""
     session.install(BLACK_VERSION)
+    session.run("python", "-m", "pip", "freeze")
     session.run(
         "black",
         *LINT_PATHS,
@@ -115,6 +117,7 @@ def format(session):
     session.install(BLACK_VERSION, ISORT_VERSION)
     # Use the --fss option to sort imports using strict alphabetical order.
     # See https://pycqa.github.io/isort/docs/configuration/options.html#force-sort-within-sections
+    session.run("python", "-m", "pip", "freeze")
     session.run(
         "isort",
         "--fss",
@@ -130,6 +133,7 @@ def format(session):
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
     session.install("docutils", "pygments")
+    session.run("python", "-m", "pip", "freeze")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 
@@ -168,6 +172,8 @@ def default(session, tests_path):
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     install_unittest_dependencies(session, "-c", constraints_path)
+
+    session.run("python", "-m", "pip", "freeze")
 
     # Run py.test against the unit tests.
     session.run(
@@ -342,6 +348,8 @@ def system(session):
 
     install_systemtest_dependencies(session, "-c", constraints_path)
 
+    session.run("python", "-m", "pip", "freeze")
+
     # Run py.test against the system tests.
     if system_test_exists:
         session.run(
@@ -371,6 +379,8 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
+    session.run("python", "-m", "pip", "freeze")
+
     session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
@@ -397,6 +407,7 @@ def docs(session):
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
+    session.run("python", "-m", "pip", "freeze")
     session.run(
         "sphinx-build",
         "-W",  # warnings as errors
@@ -432,6 +443,7 @@ def docfx(session):
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
+    session.run("python", "-m", "pip", "freeze")
     session.run(
         "sphinx-build",
         "-T",  # show full traceback on exception
@@ -515,6 +527,7 @@ def prerelease_deps(session):
         "requests",
     ]
     session.install(*other_deps)
+    session.run("python", "-m", "pip", "freeze")
 
     # Print out prerelease package versions
     session.run(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
     "packaging >= 17.0",
-    "pandas >= 0.24.2",
+    "pandas >= 1.2.0",
     "pyarrow>=3.0.0",
     "numpy >= 1.16.6",
 ]

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,7 +5,6 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 packaging==17.0
-# Make sure we test with pandas 0.24.2. The Python version isn't that relevant.
-pandas==0.24.2
+pandas==1.2.0
 pyarrow==3.0.0
 numpy==1.16.6


### PR DESCRIPTION
fix: Updates noxfile with the pip freeze command to help check version numbers in the locs AND updated the lowest pandas version from 0.24.x to 1.2.0 (released in Dec 2020).

Fixes #314 🦕
Fixes #323 🦕
