### PR TITLE
chore: Update Python version to 3.13 in compliance workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['2.13']
+        python: ['3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.13']
+        python: ['2.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.12']
+        python: ['3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.12']
+        python: ['3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Updates the Python version used in the matrix strategy for both the `compliance` and `compliance-prerelease` jobs in the `.github/workflows/compliance.yml` file from 3.12 to 3.13.