### PR TITLE
fix: updates json array registration

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,6 @@ branchProtectionRules:
     - 'cla/google'
     - 'docs'
     - 'lint'
-    - 'unit (3.8)'
     - 'unit (3.9)'
     - 'unit (3.10)'
     - 'unit (3.11)'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.8"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -103,7 +103,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/db_dtypes/json.py
+++ b/db_dtypes/json.py
@@ -277,5 +277,10 @@ class JSONArrowType(pa.ExtensionType):
 
 
 # Register the type to be included in RecordBatches, sent over IPC and received in
-# another Python process.
-pa.register_extension_type(JSONArrowType())
+# another Python process. Also handle potential pre-registration
+try:
+    pa.register_extension_type(JSONArrowType())
+except pa.ArrowKeyError:
+    # Type 'dbjson' might already be registered if the module is reloaded,
+    # which is okay.
+    pass

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,8 +35,6 @@ LINT_PATHS = ["docs", "db_dtypes", "tests", "noxfile.py", "setup.py"]
 DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
-    "3.7",
-    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "db_dtypes", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.9"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.9",
@@ -54,7 +54,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.9"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/owlbot.py
+++ b/owlbot.py
@@ -28,7 +28,7 @@ common = gcp.CommonTemplates()
 # Add templated files
 # ----------------------------------------------------------------------------
 templated_files = common.py_library(
-    system_test_python_versions=["3.8"],
+    system_test_python_versions=["3.9"],
     cov_level=100,
     intersphinx_dependencies={
         "pandas": "https://pandas.pydata.org/pandas-docs/stable/"

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,6 @@ setup(
     ],
     platforms="Posix; MacOS X; Windows",
     install_requires=dependencies,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     tests_require=["pytest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,6 @@ setup(
     ],
     platforms="Posix; MacOS X; Windows",
     install_requires=dependencies,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     tests_require=["pytest"],
 )

--- a/tests/unit/test__init__.py
+++ b/tests/unit/test__init__.py
@@ -83,3 +83,62 @@ def test_check_python_version_does_not_warn_on_supported(mock_version_tuple):
 
         # Assert that warnings.warn was NOT called
         mock_warn_call.assert_not_called()
+
+
+def test_determine_all_includes_json_when_available():
+    """
+    Test that _determine_all includes JSON types when both are truthy.
+    """
+
+    from db_dtypes import _determine_all
+
+    # Simulate available types (can be any truthy object)
+    mock_json_array = object()
+    mock_json_dtype = object()
+
+    result = _determine_all(mock_json_array, mock_json_dtype)
+
+    expected_all = [
+        "__version__",
+        "DateArray",
+        "DateDtype",
+        "TimeArray",
+        "TimeDtype",
+        "JSONDtype",
+        "JSONArray",
+        "JSONArrowType",
+    ]
+    assert set(result) == set(expected_all)
+    assert "JSONDtype" in result
+    assert "JSONArray" in result
+    assert "JSONArrowType" in result
+
+
+@pytest.mark.parametrize(
+    "mock_array, mock_dtype",
+    [
+        (None, object()),  # JSONArray is None
+        (object(), None),  # JSONDtype is None
+        (None, None),  # Both are None
+    ],
+)
+def test_determine_all_excludes_json_when_unavailable(mock_array, mock_dtype):
+    """
+    Test that _determine_all excludes JSON types if either is falsy.
+    """
+
+    from db_dtypes import _determine_all
+
+    result = _determine_all(mock_array, mock_dtype)
+
+    expected_all = [
+        "__version__",
+        "DateArray",
+        "DateDtype",
+        "TimeArray",
+        "TimeDtype",
+    ]
+    assert set(result) == set(expected_all)
+    assert "JSONDtype" not in result
+    assert "JSONArray" not in result
+    assert "JSONArrowType" not in result

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -249,16 +249,16 @@ def cleanup_json_module_for_reload():
         pass  # Already registered is the state we want before the test runs
 
     # Remove the module from sys.modules so importlib.reload re-executes it
-    if json_module_name in sys.modules: # COVERAGE FAIL: 252->255
+    if json_module_name in sys.modules:  # COVERAGE FAIL: 252->255
         del sys.modules[json_module_name]
 
     yield  # Run the test that uses this fixture
 
     # Cleanup: Put the original module back if it existed
     # This helps isolate from other tests that might import db_dtypes.json
-    if original_module: # COVERAGE FAIL: 259-261
+    if original_module:  # COVERAGE FAIL: 259-261
         sys.modules[json_module_name] = original_module
-    elif json_module_name in sys.modules: # COVERAGE FAIL: 261->exit
+    elif json_module_name in sys.modules:  # COVERAGE FAIL: 261->exit
         # If the test re-imported it but it wasn't there originally, remove it
         del sys.modules[json_module_name]
 
@@ -275,7 +275,7 @@ def test_json_arrow_type_reregistration_is_handled(cleanup_json_module_for_reloa
     # Re-importing the module after the fixture removed it from sys.modules
     # forces Python to execute the module's top-level code again.
     # This includes the pa.register_extension_type call.
-    
+
     assert "db_dtypes.json" not in sys.modules
     try:
         import db_dtypes.json  # noqa: F401
@@ -284,7 +284,7 @@ def test_json_arrow_type_reregistration_is_handled(cleanup_json_module_for_reloa
             True
         ), "Module re-import completed without error, except block likely worked."
 
-    except pa.ArrowKeyError: # COVERAGE FAIL: 287-294
+    except pa.ArrowKeyError:  # COVERAGE FAIL: 287-294
         # If this exception escapes, the except block in db_dtypes/json.py failed.
         pytest.fail(
             "pa.ArrowKeyError was raised during module reload, "

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import sys
 
 import numpy as np
 import pandas as pd
@@ -224,3 +225,70 @@ def test_json_arrow_record_batch():
         == '{"null_field":null,"order":{"address":{"city":"Anytown","street":"123 Main St"},"items":["book","pen","computer"],"total":15}}'
     )
     assert s[6] == "null"
+
+
+@pytest.fixture
+def cleanup_json_module_for_reload():
+    """
+    Fixture to ensure db_dtypes.json is registered and then removed
+    from sys.modules to allow testing the registration except block via reload.
+    """
+
+    json_module_name = "db_dtypes.json"
+    original_module = sys.modules.get(json_module_name)
+
+    # Ensure the type is registered initially (usually by the first import)
+    try:
+        # Make sure the module is loaded so the type exists
+        import db_dtypes.json
+
+        # Explicitly register just in case it wasn't, or was cleaned up elsewhere.
+        # This might raise ArrowKeyError itself if already registered, which is fine here.
+        pa.register_extension_type(db_dtypes.json.JSONArrowType())
+    except pa.ArrowKeyError:
+        pass  # Already registered is the state we want before the test runs
+    except ImportError:
+        pytest.skip("Could not import db_dtypes.json to set up test.")
+
+    # Remove the module from sys.modules so importlib.reload re-executes it
+    if json_module_name in sys.modules:
+        del sys.modules[json_module_name]
+
+    yield  # Run the test that uses this fixture
+
+    # Cleanup: Put the original module back if it existed
+    # This helps isolate from other tests that might import db_dtypes.json
+    if original_module:
+        sys.modules[json_module_name] = original_module
+    elif json_module_name in sys.modules:
+        # If the test re-imported it but it wasn't there originally, remove it
+        del sys.modules[json_module_name]
+
+    # Note: PyArrow doesn't have a public API to unregister types easily,
+    # thus we are using the testing pattern of module isolation/reloading.
+
+
+def test_json_arrow_type_reregistration_is_handled(cleanup_json_module_for_reload):
+    """
+    Verify that attempting to re-register JSONArrowType via module reload
+    is caught by the except block and does not raise an error.
+    """
+
+    try:
+        # Re-importing the module after the fixture removed it from sys.modules
+        # forces Python to execute the module's top-level code again.
+        # This includes the pa.register_extension_type call.
+        import db_dtypes.json  # noqa: F401
+
+        assert (
+            True
+        ), "Module re-import completed without error, except block likely worked."
+
+    except pa.ArrowKeyError:
+        # If this exception escapes, the except block in db_dtypes/json.py failed.
+        pytest.fail(
+            "pa.ArrowKeyError was raised during module reload, "
+            "indicating the except block failed."
+        )
+    except Exception as e:
+        pytest.fail(f"An unexpected exception occurred during module reload: {e}")


### PR DESCRIPTION
Trying to break up a large PR (#337) into smaller segments.

This adds tests to address some coverage issues that appeared while trying to deprecate Python 3.7 and 3.8.