### PR TITLE
chore: ignore docs.yml and lint.yml in renovate

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -43,7 +43,7 @@ s.move(
         ".github/workflows/docs.yml", # to avoid overwriting python version
         ".github/workflows/lint.yml", # to avoid overwriting python version
         "noxfile.py",
-        "renovate.json",
+        "renovate.json", # to avoid overwriting the ignorePaths list.
     ]
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -43,7 +43,10 @@ s.move(
         ".github/workflows/docs.yml", # to avoid overwriting python version
         ".github/workflows/lint.yml", # to avoid overwriting python version
         "noxfile.py",
-        "renovate.json", # to avoid overwriting the ignorePaths list.
+        "renovate.json", # to avoid overwriting the ignorePaths list additions:
+                         # ".github/workflows/docs.yml AND lint.yml" specifically
+                         # the version of python referenced in each of those files.
+                         # Currently renovate bot wants to change 3.10 to 3.13.
     ]
 )
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -43,6 +43,7 @@ s.move(
         ".github/workflows/docs.yml", # to avoid overwriting python version
         ".github/workflows/lint.yml", # to avoid overwriting python version
         "noxfile.py",
+        "renovate.json",
     ]
 )
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml", ".github/workflows/docs.yml", ".github/workflows/lint.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml", ".github/workflows/docs.yml", ".github/workflows/lint.yml"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
This change updates renovate.json to prevent renovate-bot from updating the specified workflow files.

