### PR TITLE
chore: librarian release pull request: 20251111T193804Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: db-dtypes
-    version: 1.4.3
+    version: 1.5.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/db-dtypes/#history
 
+## [1.5.0](https://github.com/googleapis/google-cloud-python/compare/db-dtypes-v1.4.3...db-dtypes-v1.5.0) (2025-11-11)
+
+
+### Features
+
+* some feature ([5153f9509c8ccd8f11566d9d3b7cbe3cead75459](https://github.com/googleapis/google-cloud-python/commit/5153f9509c8ccd8f11566d9d3b7cbe3cead75459))
+
 ## [1.4.4](https://github.com/googleapis/python-db-dtypes-pandas/compare/v1.4.3...v1.4.4) (2025-09-08)
 
 

--- a/db_dtypes/version.py
+++ b/db_dtypes/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.4"  # pragma: NO COVER
+__version__ = "1.5.0"  # pragma: NO COVER

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import
 
+
 import os
 import pathlib
 import re


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>db-dtypes: 1.5.0</summary>

## [1.5.0](https://github.com/googleapis/python-db-dtypes-pandas/compare/v1.4.3...v1.5.0) (2025-11-11)

### Features

* some feature ([5153f950](https://github.com/googleapis/python-db-dtypes-pandas/commit/5153f950))

</details>