### PR TITLE
feat: Add support for Python 3.14

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.14']
+        python: ['3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.14']
+        python: ['3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v5

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.13']
+        python: ['3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.13']
+        python: ['3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v5

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.13']
+        python: ['3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.13']
+        python: ['3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.kokoro/samples/python3.14/common.cfg
+++ b/.kokoro/samples/python3.14/common.cfg
@@ -1,0 +1,40 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Specify which tests to run
+env_vars: {
+    key: "RUN_TESTS_SESSION"
+    value: "py-3.14"
+}
+
+# Declare build specific Cloud project.
+env_vars: {
+    key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    value: "python-docs-samples-tests-313"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/python-db-dtypes-pandas/.kokoro/test-samples.sh"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
+}
+
+# Download secrets for samples
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "python-db-dtypes-pandas/.kokoro/trampoline_v2.sh"

--- a/.kokoro/samples/python3.14/common.cfg
+++ b/.kokoro/samples/python3.14/common.cfg
@@ -16,7 +16,7 @@ env_vars: {
 # Declare build specific Cloud project.
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
-    value: "python-docs-samples-tests-313"
+    value: "python-docs-samples-tests-314"
 }
 
 env_vars: {

--- a/.kokoro/samples/python3.14/continuous.cfg
+++ b/.kokoro/samples/python3.14/continuous.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "True"
+}

--- a/.kokoro/samples/python3.14/periodic-head.cfg
+++ b/.kokoro/samples/python3.14/periodic-head.cfg
@@ -1,0 +1,11 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "True"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/python-db-dtypes-pandas/.kokoro/test-samples-against-head.sh"
+}

--- a/.kokoro/samples/python3.14/periodic.cfg
+++ b/.kokoro/samples/python3.14/periodic.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "False"
+}

--- a/.kokoro/samples/python3.14/presubmit.cfg
+++ b/.kokoro/samples/python3.14/presubmit.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "True"
+}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13 on both UNIX and Windows.
+  3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -72,7 +72,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To run a single unit test::
 
-    $ nox -s unit-3.13 -- -k <name of test>
+    $ nox -s unit-3.14 -- -k <name of test>
 
 
   .. note::
@@ -228,6 +228,7 @@ We support:
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
+-  `Python 3.14`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
@@ -236,6 +237,7 @@ We support:
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
 .. _Python 3.13: https://docs.python.org/3.13/
+.. _Python 3.14: https://docs.python.org/3.14/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,6 +41,7 @@ UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",

--- a/noxfile.py
+++ b/noxfile.py
@@ -219,14 +219,11 @@ def prerelease(session, tests_path):
         "--upgrade",
         "pyarrow",
     )
-    # Avoid pandas==2.2.0rc0 as this version causes PyArrow to fail. Once newer
-    # prerelease comes out, this constraint can be removed. See
-    # https://github.com/googleapis/python-db-dtypes-pandas/issues/234
     session.install(
         "--prefer-binary",
         "--pre",
         "--upgrade",
-        "pandas!=2.2.0rc0",
+        "pandas<3.0.0rc0",
     )
     session.install(
         "mock",

--- a/samples/snippets/noxfile.py
+++ b/samples/snippets/noxfile.py
@@ -89,7 +89,7 @@ def get_pytest_env_vars() -> Dict[str, str]:
 
 # DO NOT EDIT - automatically generated.
 # All versions used to test samples.
-ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 # Any default versions that should be ignored.
 IGNORED_VERSIONS = TEST_CONFIG["ignored_versions"]

--- a/samples/snippets/noxfile.py
+++ b/samples/snippets/noxfile.py
@@ -89,7 +89,7 @@ def get_pytest_env_vars() -> Dict[str, str]:
 
 # DO NOT EDIT - automatically generated.
 # All versions used to test samples.
-ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 # Any default versions that should be ignored.
 IGNORED_VERSIONS = TEST_CONFIG["ignored_versions"]

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dependencies = [
     "numpy >= 1.24.0, <= 2.2.6 ; python_version == '3.10'",
     "numpy >= 1.24.0 ; python_version != '3.10'",
     "packaging >= 24.2.0",
-    "pandas >= 1.5.3",
+    "pandas >= 1.5.3, < 3.0.0",
     "pyarrow >= 13.0.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
         "Topic :: Database :: Front-Ends",
     ],

--- a/tests/unit/test_date.py
+++ b/tests/unit/test_date.py
@@ -137,9 +137,9 @@ def test_date_set_slice_null():
         ("1-3", "Bad date string: '1-3'"),
         ("1", "Bad date string: '1'"),
         ("", "Bad date string: ''"),
-        ("2021-2-99", "day is out of range for month"),
+        ("2021-2-99", "day is out of range for month|day .* must be in range .*"),
         ("2021-99-1", "month must be in 1[.][.]12"),
-        ("10000-1-1", "year 10000 is out of range"),
+        ("10000-1-1", "year 10000 is out of range|year must be in .*"),
     ],
 )
 def test_date_parsing_errors(value, error):

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -27,14 +27,14 @@ def _import_side_effect(module_name, result_return=None, result_raise=None):
     arguments. Otherwise, it will default to regular import behaviour
     """
 
-    def _impl(name, *args, **kwargs):
+    def _impl(name, *args, **kwargs):  # pragma: no cover
         if name == module_name:
             if result_raise:
                 raise result_raise
             else:
                 return result_return
         else:
-            return REAL_IMPORT(name, *args, **kwargs)  # pragma: no cover
+            return REAL_IMPORT(name, *args, **kwargs)
 
     return _impl
 

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -12,16 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
 import unittest.mock as mock
 
 import db_dtypes.pandas_backports as pandas_backports
+
+REAL_IMPORT = builtins.__import__
+
+
+def _import_side_effect(module_name, result_return=None, result_raise=None):
+    """
+    Builds a side-effect for mocking the import function. 
+    If the imported package matches `name`, it will return or raise based on
+    arguments. Otherwise, it will default to regular import behaviour
+    """
+    def _impl(name, *args, **kwargs):
+        if name == module_name:
+            if result_raise:
+                raise result_raise
+            else:
+                return result_return
+        else:
+            return REAL_IMPORT(name, *args, **kwargs)
+    return _impl
 
 
 @mock.patch("builtins.__import__")
 def test_import_default_module_found(mock_import):
     mock_module = mock.MagicMock()
-    mock_module.OpsMixin = "OpsMixin_from_module"  # Simulate successful import
-    mock_import.return_value = mock_module
+    mock_module.OpsMixin = "OpsMixin_from_module"
+
+    mock_import.side_effect = _import_side_effect("module_name", mock_module)
 
     default_class = type("OpsMixin", (), {})  # Dummy class
     result = pandas_backports.import_default("module_name", default=default_class)
@@ -29,8 +50,8 @@ def test_import_default_module_found(mock_import):
 
 
 @mock.patch("builtins.__import__")
-def test_import_default_module_not_found(mock_import):
-    mock_import.side_effect = ModuleNotFoundError
+def test_import_default_module_not_foundX(mock_import):
+    mock_import.side_effect = _import_side_effect("module_name", result_raise=ModuleNotFoundError)
 
     default_class = type("OpsMixin", (), {})  # Dummy class
     result = pandas_backports.import_default("module_name", default=default_class)
@@ -48,6 +69,7 @@ def test_import_default_force_true(mock_import):
     result = pandas_backports.import_default(
         "any_module_name", force=True, default=default_class
     )
+    assert mock_import.call_count == 0
 
     # Assert that the returned value is the default class itself
     assert result is default_class

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -27,13 +27,13 @@ def _import_side_effect(module_name, result_return=None, result_raise=None):
     arguments. Otherwise, it will default to regular import behaviour
     """
 
-    def _impl(name, *args, **kwargs):  # pragma: no cover
+    def _impl(name, *args, **kwargs):
         if name == module_name:
             if result_raise:
                 raise result_raise
             else:
                 return result_return
-        else:
+        else:  # pragma: no cover
             return REAL_IMPORT(name, *args, **kwargs)
 
     return _impl

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -36,6 +36,8 @@ def _import_side_effect(module_name, result_return=None, result_raise=None):
         else:
             return REAL_IMPORT(name, *args, **kwargs)  # pragma: no cover
 
+    return _impl
+
 
 @mock.patch("builtins.__import__")
 def test_import_default_module_found(mock_import):

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -22,10 +22,11 @@ REAL_IMPORT = builtins.__import__
 
 def _import_side_effect(module_name, result_return=None, result_raise=None):
     """
-    Builds a side-effect for mocking the import function. 
+    Builds a side-effect for mocking the import function.
     If the imported package matches `name`, it will return or raise based on
     arguments. Otherwise, it will default to regular import behaviour
     """
+
     def _impl(name, *args, **kwargs):
         if name == module_name:
             if result_raise:
@@ -34,6 +35,7 @@ def _import_side_effect(module_name, result_return=None, result_raise=None):
                 return result_return
         else:
             return REAL_IMPORT(name, *args, **kwargs)
+
     return _impl
 
 
@@ -50,8 +52,10 @@ def test_import_default_module_found(mock_import):
 
 
 @mock.patch("builtins.__import__")
-def test_import_default_module_not_foundX(mock_import):
-    mock_import.side_effect = _import_side_effect("module_name", result_raise=ModuleNotFoundError)
+def test_import_default_module_not_found(mock_import):
+    mock_import.side_effect = _import_side_effect(
+        "module_name", result_raise=ModuleNotFoundError
+    )
 
     default_class = type("OpsMixin", (), {})  # Dummy class
     result = pandas_backports.import_default("module_name", default=default_class)

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -34,9 +34,7 @@ def _import_side_effect(module_name, result_return=None, result_raise=None):
             else:
                 return result_return
         else:
-            return REAL_IMPORT(name, *args, **kwargs)
-
-    return _impl
+            return REAL_IMPORT(name, *args, **kwargs)  # pragma: no cover
 
 
 @mock.patch("builtins.__import__")

--- a/tests/unit/test_pandas_backports.py
+++ b/tests/unit/test_pandas_backports.py
@@ -33,7 +33,7 @@ def _import_side_effect(module_name, result_return=None, result_raise=None):
                 raise result_raise
             else:
                 return result_return
-        else:  # pragma: no cover
+        else:  # pragma: NO COVER
             return REAL_IMPORT(name, *args, **kwargs)
 
     return _impl


### PR DESCRIPTION
This PR adds Python 3.14 as a supported version, and fixed tests for the new version

This PR also adds a dependency bound to pandas, as the [upcoming 3.0.0 version is incompatible](https://github.com/googleapis/google-cloud-python/issues/15509)