### PR TITLE
chore: librarian release pull request: 20251215T132415Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: db-dtypes
-    version: 1.4.3
+    version: 1.5.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/db-dtypes/#history
 
+## [1.5.0](https://github.com/googleapis/google-cloud-python/compare/db-dtypes-v1.4.3...db-dtypes-v1.5.0) (2025-12-15)
+
+
+### Features
+
+* Add support for Python 3.14 (#380) ([c164a47be909203606cf982d6f0becc6c8efdb09](https://github.com/googleapis/google-cloud-python/commit/c164a47be909203606cf982d6f0becc6c8efdb09))
+
 ## [1.4.4](https://github.com/googleapis/python-db-dtypes-pandas/compare/v1.4.3...v1.4.4) (2025-09-08)
 
 

--- a/db_dtypes/version.py
+++ b/db_dtypes/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.4"  # pragma: NO COVER
+__version__ = "1.5.0"  # pragma: NO COVER


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>db-dtypes: 1.5.0</summary>

## [1.5.0](https://github.com/googleapis/python-db-dtypes-pandas/compare/v1.4.3...v1.5.0) (2025-12-15)

### Features

* Add support for Python 3.14 (#380) ([c164a47b](https://github.com/googleapis/python-db-dtypes-pandas/commit/c164a47b))

</details>